### PR TITLE
Fix Maven support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-02-12
+
+### Added
+
+- **Maven Build Goal Support in Run Configuration**:
+  - Build task dropdown now shows Maven goals for Maven projects
+  - Added support for multi-goal entry (e.g., `clean package`)
+  - Added one-time migration prompt for existing Maven projects using Gradle-only tasks
+
+### Fixed
+
+- **Maven projects failing to build from Run Configuration**:
+  - Replaced Gradle-only defaults with Maven-aware defaults (`package` for Maven projects)
+  - Added Maven goal normalization when old Gradle task names are present
+- **Hot Reload did not support Maven projects**:
+  - Hot Reload build step now supports Maven wrapper/global Maven in addition to Gradle
+  - JAR resolution now checks both `build/libs` and `target`
+- **Project detection missed Maven-only setups**:
+  - Startup run configuration setup now detects Hytale Maven dependencies from `pom.xml`
+- **Reconfigure action message outdated**:
+  - Updated detection guidance to include `pom.xml`
+
+### Changed
+
+- **Maven project template deployment behavior**:
+  - Removed generated `maven-resources-plugin` copy-to-mods step from `pom.xml`
+  - Plugin deployment is now handled only by the IntelliJ plugin run/deploy flow
+- **plugin.xml text normalization**:
+  - Replaced non-ASCII separators/arrows with ASCII-safe text to avoid encoding artifacts
+
 ## [1.4.2] - 2026-02-06
 
 ### Fixed
@@ -219,7 +249,8 @@
 - Supports IntelliJ IDEA 2024.3+
 - Requires Java 25 for Hytale development
 
-[Unreleased]: https://github.com/HytaleDocs/hytale-intellij-plugin/compare/v1.4.2...HEAD
+[Unreleased]: https://github.com/HytaleDocs/hytale-intellij-plugin/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/HytaleDocs/hytale-intellij-plugin/compare/v1.4.2...v1.5.0
 [1.4.2]: https://github.com/HytaleDocs/hytale-intellij-plugin/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/HytaleDocs/hytale-intellij-plugin/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/HytaleDocs/hytale-intellij-plugin/compare/v1.3.9...v1.4.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.hytaledocs.hytale
 pluginName = Hytale Development Tools
 pluginRepositoryUrl = https://github.com/HytaleDocs/hytale-intellij-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 1.4.2
+pluginVersion = 1.5.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 242

--- a/src/main/kotlin/com/hytaledocs/intellij/actions/ReconfigureRunConfigAction.kt
+++ b/src/main/kotlin/com/hytaledocs/intellij/actions/ReconfigureRunConfigAction.kt
@@ -39,7 +39,11 @@ class ReconfigureRunConfigAction : AnAction() {
         val pluginInfo = PluginInfoDetector.detect(basePath, project.name)
 
         if (pluginInfo == null) {
-            showNotification(project, "Could not detect plugin info. Make sure manifest.json or build.gradle exists.", NotificationType.ERROR)
+            showNotification(
+                project,
+                "Could not detect plugin info. Make sure manifest.json, pom.xml, or build.gradle exists.",
+                NotificationType.ERROR
+            )
             return
         }
 
@@ -53,7 +57,7 @@ class ReconfigureRunConfigAction : AnAction() {
 
         showNotification(
             project,
-            "Run configuration updated:\n• Plugin: ${pluginInfo.groupId}:${pluginInfo.modName}\n• JAR: ${pluginInfo.jarPath}",
+            "Run configuration updated:\n- Plugin: ${pluginInfo.groupId}:${pluginInfo.modName}\n- JAR: ${pluginInfo.jarPath}",
             NotificationType.INFORMATION
         )
 

--- a/src/main/kotlin/com/hytaledocs/intellij/run/HytaleRunConfigurationSetup.kt
+++ b/src/main/kotlin/com/hytaledocs/intellij/run/HytaleRunConfigurationSetup.kt
@@ -88,12 +88,17 @@ class HytaleRunConfigurationSetup : ProjectActivity {
 
         val hasIndicator = indicators.any { it.exists() }
 
-        // Also check for Hytale dependency in build.gradle
+        // Also check for Hytale dependency in build files
         val buildGradle = File(basePath, "build.gradle")
         val buildGradleKts = File(basePath, "build.gradle.kts")
+        val pomXml = File(basePath, "pom.xml")
         val hasHytaleDep = when {
             buildGradle.exists() -> buildGradle.readText().contains("HytaleServer")
             buildGradleKts.exists() -> buildGradleKts.readText().contains("HytaleServer")
+            pomXml.exists() -> {
+                val pomContent = pomXml.readText()
+                pomContent.contains("com.hypixel.hytale") && pomContent.contains("<artifactId>Server</artifactId>")
+            }
             else -> false
         }
 

--- a/src/main/kotlin/com/hytaledocs/intellij/run/HytaleServerRunConfiguration.kt
+++ b/src/main/kotlin/com/hytaledocs/intellij/run/HytaleServerRunConfiguration.kt
@@ -8,6 +8,7 @@ import com.intellij.execution.configurations.RunProfileState
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
+import java.io.File
 
 /**
  * Run configuration for Hytale Server.
@@ -41,7 +42,7 @@ class HytaleServerRunConfiguration(
         set(value) { options.buildBeforeRun = value }
 
     var buildTask: String
-        get() = options.buildTask ?: "shadowJar"
+        get() = options.buildTask ?: defaultBuildTask()
         set(value) { options.buildTask = value }
 
     // Deploy settings
@@ -101,4 +102,10 @@ class HytaleServerRunConfiguration(
     var hotReloadEnabled: Boolean
         get() = options.hotReloadEnabled
         set(value) { options.hotReloadEnabled = value }
+
+    private fun defaultBuildTask(): String {
+        val basePath = project.basePath ?: return "package"
+        val hasPom = File(basePath, "pom.xml").exists()
+        return if (hasPom) "package" else "shadowJar"
+    }
 }

--- a/src/main/kotlin/com/hytaledocs/intellij/run/HytaleServerRunConfigurationOptions.kt
+++ b/src/main/kotlin/com/hytaledocs/intellij/run/HytaleServerRunConfigurationOptions.kt
@@ -10,7 +10,7 @@ class HytaleServerRunConfigurationOptions : RunConfigurationOptions() {
 
     // Build settings
     var buildBeforeRun by property(true)
-    var buildTask by string("shadowJar")
+    var buildTask by string("package")
 
     // Deploy settings
     var deployPlugin by property(true)

--- a/src/main/kotlin/com/hytaledocs/intellij/toolWindow/HytaleToolWindowFactory.kt
+++ b/src/main/kotlin/com/hytaledocs/intellij/toolWindow/HytaleToolWindowFactory.kt
@@ -695,6 +695,7 @@ class HytaleToolWindowPanel(
         // Contributors list
         val contributors = listOf(
             Triple("maartenpeels", "Mac & Linux support", "https://github.com/maartenpeels")
+            Triple("chums122", "Fix Maven support", "https://github.com/chums122")
         )
 
         contributors.forEach { (name, contribution, url) ->

--- a/src/main/kotlin/com/hytaledocs/intellij/toolWindow/HytaleToolWindowFactory.kt
+++ b/src/main/kotlin/com/hytaledocs/intellij/toolWindow/HytaleToolWindowFactory.kt
@@ -694,7 +694,7 @@ class HytaleToolWindowPanel(
 
         // Contributors list
         val contributors = listOf(
-            Triple("maartenpeels", "Mac & Linux support", "https://github.com/maartenpeels")
+            Triple("maartenpeels", "Mac & Linux support", "https://github.com/maartenpeels"),
             Triple("chums122", "Fix Maven support", "https://github.com/chums122")
         )
 

--- a/src/main/kotlin/com/hytaledocs/intellij/wizard/HytaleModuleBuilder.kt
+++ b/src/main/kotlin/com/hytaledocs/intellij/wizard/HytaleModuleBuilder.kt
@@ -1622,31 +1622,6 @@ class HytaleModuleBuilder : ModuleBuilder() {
                                 </execution>
                             </executions>
                         </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-resources-plugin</artifactId>
-                            <version>3.3.1</version>
-                            <executions>
-                                <execution>
-                                    <id>copy-to-mods</id>
-                                    <phase>package</phase>
-                                    <goals>
-                                        <goal>copy-resources</goal>
-                                    </goals>
-                                    <configuration>
-                                        <outputDirectory>${'$'}{project.basedir}/server/mods</outputDirectory>
-                                        <resources>
-                                            <resource>
-                                                <directory>${'$'}{project.build.directory}</directory>
-                                                <includes>
-                                                    <include>${'$'}{project.build.finalName}.jar</include>
-                                                </includes>
-                                            </resource>
-                                        </resources>
-                                    </configuration>
-                                </execution>
-                            </executions>
-                        </plugin>
                     </plugins>
                 </build>
             </project>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -121,10 +121,10 @@
 
 <h2>Resources</h2>
 <p>
-    <a href="https://hytale-docs.com">Documentation</a> ·
-    <a href="https://hytale-docs.com/api">API Reference</a> ·
-    <a href="https://hytale-docs.com/modding/plugins/project-setup">Plugin Guide</a> ·
-    <a href="https://discord.gg/yAjaFBH4Y8">Discord</a> ·
+    <a href="https://hytale-docs.com">Documentation</a> |
+    <a href="https://hytale-docs.com/api">API Reference</a> |
+    <a href="https://hytale-docs.com/modding/plugins/project-setup">Plugin Guide</a> |
+    <a href="https://discord.gg/yAjaFBH4Y8">Discord</a> |
     <a href="https://github.com/HytaleDocs/hytale-intellij-plugin">GitHub</a>
 </p>
 
@@ -408,7 +408,7 @@
             <action id="HytaleDocs.HotReloadPlugin"
                     class="com.hytaledocs.intellij.actions.HotReloadPluginAction"
                     text="Hot Reload Plugin"
-                    description="Build and reload your plugin on the running server (Build → Unload → Deploy → Load)"
+                    description="Build and reload your plugin on the running server (Build -> Unload -> Deploy -> Load)"
                     icon="AllIcons.Actions.ForceRefresh"/>
 
             <separator/>


### PR DESCRIPTION
### Summary
This PR completes Maven support across run/build/deploy paths and removes Maven/Gradle mismatches that caused build lifecycle failures.

### What changed
1. Maven-aware run config defaults
    * Run config default build task is now Maven-aware:
        * Maven project: `package`
        * Gradle project: `shadowJar`
    * Updated persisted default and runtime fallback behavior.

2. Build task UI now adapts by build system
    * Maven projects show Maven goals in the run configuration editor:
        * `package`
        * `clean package`
        * `install`
        * `verify`
        * `clean`
    * Gradle projects still show:
        * `shadowJar`
        * `build`
        * `jar`
        * `assemble`

3. One-time migration prompt for existing Maven configs
    * On startup, if pom.xml exists and the existing run config uses Gradle-only tasks (`build`, `shadowJar`, `jar`, `assemble`), the plugin shows a notification with:
        * `Migrate to package`
        * `Keep current task`
    * Choice is stored per project so the prompt appears only once.

4. Maven execution hardening in run state
    * Supports multi-token build input (e.g. `clean package`).
    * Normalizes Gradle-only tasks to `package `when executing with Maven.

5. Hot Reload now supports Maven too
    * `HotReloadPluginAction` build step now supports:
        * Gradle wrapper / global Gradle
        * Maven wrapper / global Maven
    * Includes Maven goal normalization and multi-token goal support.
    * AR resolution now checks both `build/libs` and `target`.

6. Improved Maven project detection during startup setup
    * `isHytaleProject()` now also checks pom.xml for Hytale dependency markers:
        * `com.hypixel.hytale`
        * `<artifactId>Server</artifactId>`

7. Better reconfigure messaging
    * Updated error text to include Maven:
        * manifest.json, pom.xml, or build.gradle

8. Remove duplicate Maven deploy behavior
    * Removed generated `maven-resources-plugin` `copy-to-mods` execution from Maven template pom.xml.
    * Deployment is now handled only by the plugin run/deploy flow.

9. Text encoding cleanup in plugin metadata
    * Replaced non-ASCII separators/arrows in plugin.xml with ASCII-safe equivalents (`|`, `->`) to avoid mojibake.

### Why
Maven projects were failing due to Gradle-centric task defaults and options, and hot reload was Gradle-only. This PR aligns defaults, UI, startup behavior, and execution paths with Maven semantics.

### Validation
gradlew.bat -q compileKotlin passes after changes.